### PR TITLE
Add examples of basic use of Clustergrammer2

### DIFF
--- a/docs/clustergrammer2.rst
+++ b/docs/clustergrammer2.rst
@@ -72,7 +72,6 @@ The net object is automaticllay created when you import Clustergrammer2. It is u
 
 ::
 
-  # make imports and instantiate a Network instance with the widget class as an argument
   from clustergrammer2 import *
 
   # load matrix file
@@ -86,9 +85,11 @@ The net object is automaticllay created when you import Clustergrammer2. It is u
 
 **General Purpose DataFrame Viewer**
 
-Clustergrammer-Widget can also be used as a general purpose `Pandas`_ DataFrame viewer. Below is an example of how to visualize a Pandas DataFrame, ``df``, by loading it into the ``net`` object:
+Clustergrammer2 can also be used as a general purpose `Pandas`_ DataFrame viewer. Below is an example of how to visualize a Pandas DataFrame, ``df``, by loading it into the ``net`` object:
 ::
 
+  from clustergrammer2 import *
+     
   # load DataFrame
   net.load_df(df)
 

--- a/docs/clustergrammer2.rst
+++ b/docs/clustergrammer2.rst
@@ -30,12 +30,13 @@ Clustergrammer2's source code can be found in the `Clustergrammer2 GitHub repo`_
 Contact
 =======
 
-Please :ref:`contact` Nicolas Fernandez and Avi Ma'ayan with questions, use the GitHub `issues`_ feature to report an issue, or use the `gitter`_ discussion board to discuss the project.
+Please `contact`_ Nicolas Fernandez and Avi Ma'ayan with questions, use the GitHub `issues`_ feature to report an issue, or use the `gitter`_ discussion board to discuss the project.
 
 
 
 
 
+.. _`contact`: https://clustergrammer.readthedocs.io/index.html#contact
 .. _`Clustergrammer2 GitHub repo`: https://github.com/ismms-himc/clustergrammer2
 .. _`cookie cutter`: https://github.com/jupyter-widgets/widget-ts-cookiecutter
 .. _`regl`: http://regl.party/
@@ -85,7 +86,7 @@ The net object is automaticllay created when you import Clustergrammer2. It is u
 
 **General Purpose DataFrame Viewer**
 
-Clustergrammer2 can also be used as a general purpose `Pandas`_ DataFrame viewer. Below is an example of how to visualize a Pandas DataFrame, ``df``, by loading it into the ``net`` object:
+Clustergrammer2 can also be used as a general purpose Pandas DataFrame viewer. Below is an example of how to visualize a Pandas DataFrame, ``df``, by loading it into the ``net`` object:
 ::
 
   from clustergrammer2 import *

--- a/docs/clustergrammer2.rst
+++ b/docs/clustergrammer2.rst
@@ -61,3 +61,39 @@ Please :ref:`contact` Nicolas Fernandez and Avi Ma'ayan with questions, use the 
     :alt: NBViewer-scRNA-seq
     :scale: 100%
     :target: https://nbviewer.jupyter.org/github/ismms-himc/clustergrammer2-notebooks/blob/master/notebooks/3.0_2700_PBMC_scRNA-seq.ipynb
+
+Clustergrammer2 Workflow Example
+================================
+
+The net object is automaticllay created when you import Clustergrammer2. It is used to load data, filter, normalize, cluster, and render the widget.
+
+
+**Load Data from File**
+
+::
+
+  # make imports and instantiate a Network instance with the widget class as an argument
+  from clustergrammer2 import *
+
+  # load matrix file
+  net.load_file('path/to/file.txt')
+
+  # cluster using default parameters
+  net.cluster()
+
+  # make interactive widget
+  net.widget()
+
+**General Purpose DataFrame Viewer**
+
+Clustergrammer-Widget can also be used as a general purpose `Pandas`_ DataFrame viewer. Below is an example of how to visualize a Pandas DataFrame, ``df``, by loading it into the ``net`` object:
+::
+
+  # load DataFrame
+  net.load_df(df)
+
+  # cluster using default parameters
+  net.cluster()
+
+  # make interactive widget
+  net.widget()


### PR DESCRIPTION
Initially when I started using clustergrammer2 I was always trying call `Network(Clustergrammer-Widget)` because the only explicit example of how to use the Jupyter widget was with Clustergrammer-Widget. I thought it would be helpful to give a similar example in the Clustergrammer2 documentation that shows how to use the pre-created net object.